### PR TITLE
Added support for reading cup icon sizes.

### DIFF
--- a/Patcher/Modules/file.py
+++ b/Patcher/Modules/file.py
@@ -96,6 +96,10 @@ class TXT(File):
         lines = self.read()
         lines[index - 1] = line
         self.write(lines)
+    
+    def append(self, line):
+        with open(self.path, "a", encoding = "utf-8") as file:
+            file.writelines(line + "\n")
 
 class CFG(File):
     
@@ -206,3 +210,7 @@ class TAR(File):
         os.remove(self.path)
         if self.extract_folder:
             sh.rmtree(self.extract_folder)
+    
+    def delete_extract(self):
+        sh.rmtree(self.extract_folder)
+        self.extract_folder = None


### PR DESCRIPTION
This modifies the LPAR functions of the Patcher to automatically pull the cup icon size from the download LE-CODE binaries to patch the custom patch2 LE-CODE binaries. This also changes the implementation of the performance monitor to a simpler method that is more future proofed.

To make this function, two additional functions were also added to the File module.

In the future, LPAR implementation could potentially be completely rewritten, which would remove the need for bundled LE-CODE binaries in the patch2 files, but for now this should work and fix the potential bugs from mismatched cup icon sizes.